### PR TITLE
Switched all raw `new` and `delete` to `shared_ptr` and `unique_ptr`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-g -O0")
 add_library(ParseIni parseini.cpp parseini.h)
 
+set(CMAKE_CXX_STANDARD 17)
 
 add_executable(parsetest test/test.cpp parseini.h)
 target_link_libraries(parsetest ParseIni)

--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,19 @@
 ## C++ Implementation Details
 * [ ] possibly start using unique_ptr or shared_ptr instead of raw new/delete
 * [ ] implement appropriate move and copy operators and constructors for each class
-* [ ] provide a method in `ini_file` to look up sections
-* [ ] provide a method in `ini_section` to look up entries
+* [x] provide a method in `ini_file` to look up sections‡
+* [x] provide a method in `ini_section` to look up entries‡
+* [ ] convert data structures `ini_file` and `ini_section` to maintain a map of keys for better access
+* [ ] change section and entry lookups to use map
 * [ ] *possibly provide a straight to entry method in `ini_file`*
 * [ ] provide a method for appending `ini_entries` to a section
 * [ ] provide a method for appending `ini_section` to a file
 * [ ] provide a serialization method for writing the `ini_file` out
+* [ ] move each class to its own
 
+*‡ the implementations of these methods are O(n) on the number of sections in a file
+or entries in a section, respectively. The classes should be changed to use more efficient data structures to
+optimize these methods*
 ## INI Implementation Details
 * [ ] support hierarchical section names
 * [ ] support C style backslash esacpes

--- a/parseini.cpp
+++ b/parseini.cpp
@@ -7,8 +7,10 @@
 #include <cctype>
 #include <iostream>
 #include <locale>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
 
 namespace tom {
 static std::string readfile(std::string const& filename) {
@@ -26,20 +28,59 @@ static std::string readfile(std::string const& filename) {
   return text.str();
 }
 
-ini_section::~ini_section() {
-  for (auto& v : entries)
-    delete v;
-  entries.clear();
+std::shared_ptr<ini_entry> ini_section::get_entry(std::string const& key) {
+  for (auto& entry : entries) {
+    if (entry->key == key) {
+      return entry;
+    }
+  }
+  return nullptr;
 }
 
-std::vector<ini_section*> const& ini_file::get_sections() const {
+std::pair<std::string, bool> ini_section::get_value(std::string const& key) {
+  for (auto& entry : entries) {
+    if (entry->key == key) {
+      return std::pair<std::string, bool>{entry->value, true};
+    }
+  }
+  return std::pair<std::string, bool>{"", false};
+}
+
+ini_section::~ini_section() {
+  // for (auto& v : entries)
+  //   delete v;
+  // entries.clear();
+}
+
+std::vector<std::shared_ptr<ini_section>> const& ini_file::get_sections()
+    const {
   return sections;
 }
 
+std::shared_ptr<ini_entry> ini_file::get_entry(std::string const& key) {
+  for (auto& section : sections) {
+    for (auto& entry : section->entries) {
+      if (entry->key == key) {
+        return entry;
+      }
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<ini_section> ini_file::get_section(std::string const& name) {
+  for (auto& section : sections) {
+    if (section->name == name) {
+      return section;
+    }
+  }
+  return nullptr;
+}
+
 ini_file::~ini_file() {
-  for (auto& v : sections)
-    delete v;
-  sections.clear();
+  // for (auto& v : sections)
+  //   delete v;
+  // sections.clear();
 }
 
 ini_parser::ini_parser(std::string const& filename)
@@ -59,7 +100,7 @@ std::string const& ini_parser::get_filename() const noexcept {
 
 void ini_parser::pop_section_() {
   if (current_section_ != nullptr)
-    current_section_ = current_section_->parent;
+    current_section_ = current_section_->parent.lock();
 }
 
 void ini_parser::drop_initial_whitespace() {
@@ -105,8 +146,8 @@ ini_section* ini_parser::try_consume_section() {
   std::string name = content.substr(1, n - 1);
   content.erase(0, n + 1);
   content.shrink_to_fit();
-  return new ini_section{inifile, current_section_, name,
-                         std::vector<ini_entry*>{}};
+  return new ini_section{inifile, std::weak_ptr<ini_section>{current_section_},
+                         name, std::vector<std::shared_ptr<ini_entry>>{}};
 }
 
 template <typename ch>
@@ -124,7 +165,7 @@ int is_key_identifier_char(ch c) {
   return !is_comment_char(c) && c != '\n' && c != '=';
 }
 
-int ini_parser::try_consume_comment() {
+bool ini_parser::try_consume_comment() {
   drop_initial_whitespace();
   // spleef whitespace will erase all the leading whitespace
   if (!is_comment_char(content[0]))
@@ -192,7 +233,7 @@ ini_entry* ini_parser::try_consume_entry() {
 
   s.erase(0, eat);
   s.shrink_to_fit();
-  return new ini_entry{current_section_, key, value};
+  return new ini_entry{current_section_.get(), key, value};
 }
 
 ini_file ini_parser::parse() {
@@ -207,27 +248,29 @@ ini_file ini_parser::parse() {
       if (current_section_ != nullptr)
         inifile->sections.push_back(current_section_);
 
-      current_section_ = sec;
+      current_section_ = std::shared_ptr<ini_section>(sec);
 
       // drop the rest of the line
       drop_to_newline();
       continue;
     } else {
       if (current_section_ == nullptr)
-        current_section_ =
-            new ini_section{inifile, nullptr, "<Default Section>"};
+        current_section_ = std::make_shared<ini_section>(
+            inifile, std::weak_ptr<ini_section>{},
+            std::string("<Default Section>"),
+            std::vector<std::shared_ptr<ini_entry>>{});
     }
 
     // try to consume an entry on the next line
     auto entry = try_consume_entry();
     if (entry != nullptr) {
-      current_section_->entries.push_back(entry);
+      current_section_->entries.push_back(std::shared_ptr<ini_entry>{entry});
       drop_to_newline();
       continue;
     }
 
     // if the entry fails to parse try to consume a comment
-    int i = try_consume_comment();
+    bool i = try_consume_comment();
     if (i) {
       drop_to_newline();
       continue;

--- a/parseini.h
+++ b/parseini.h
@@ -83,7 +83,7 @@ struct ini_file {
 
 class ini_parser {
   // conetent fields
-  ini_file* inifile;
+  std::unique_ptr<ini_file> inifile;
   std::string filename;
   std::string content;
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <istream>
 #include <sstream>
+#include <stdexcept>
 #include "../parseini.h"
 
 int main() {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,5 @@
+#include <array>
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <istream>
@@ -11,6 +13,29 @@ int main() {
 
   std::cout << f.name << std::endl;
   std::cout << f << std::endl;
+
+  auto section = f.get_section("FTP");
+
+  assert(section->name == "FTP");
+
+  auto port = section->get_entry("FTPPort");
+
+  assert(port->key == "FTPPort");
+  assert(port->value == "21");
+
+  std::cout << "In FTP Section: " << port->key << "=" << port->value
+            << std::endl;
+
+  std::cout << "FTPDir is equal to \""
+            << std::get<0>(section->get_value("FTPDir")) << "\"\n";
+
+  auto entry = f.get_entry("PrimaryIP");
+  assert(entry->key == "PrimaryIP");
+  assert(entry->value == "192.168.0.13");
+  assert(entry->parent->name == "BACKUP_SERVERS");
+
+  std::cout << "Setting \"" << entry->key << "\" has value \"" << entry->value
+            << "\" in section \"" << entry->parent->name << "\"\n";
 
   return 0;
 }


### PR DESCRIPTION
All of the classes used for parsing were using raw `new` and `delete` for heap allocation. All of this has been moved to `shared_ptr` and `unique_ptr` where appropriate. Some instances of non-owning pointers remain raw pointers, however, the `parent` relationship in `ini_section` was converted to a `weak_ptr` despite currently also being unused